### PR TITLE
Add Metadata Labels

### DIFF
--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -20,7 +20,7 @@ their default values. See values.yaml for all available options.
 | `chaoimage.pullPolicy`                 | Container pull policy for the `chao` container                 | `Always`                                                                    |
 | `chaoimage.repository`                 | Container image to use for the `chao` container                | `gremlin/chao`                                                              |
 | `chaoimage.tag`                        | Container image tag to deploy for the `chao` container         | `latest`                                                                    |
-| `extraMetadataLabels`                  | An extra set of labels which are applied to chao and the daemonset | `{}`                                                                    |
+| `extraMetadataLabels`                  | An extra set of labels which are applied to chao, the daemonset, and their service accounts | `{}`                                                                    |
 | `nodeSelector`                         | Map of node labels for pod assignment                          | `{}`                                                                        |
 | `tolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
 | `affinity`                             | Map of node/pod affinities                                     | `{}`                                                                        |

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -20,9 +20,10 @@ their default values. See values.yaml for all available options.
 | `chaoimage.pullPolicy`                 | Container pull policy for the `chao` container                 | `Always`                                                                    |
 | `chaoimage.repository`                 | Container image to use for the `chao` container                | `gremlin/chao`                                                              |
 | `chaoimage.tag`                        | Container image tag to deploy for the `chao` container         | `latest`                                                                    |
+| `extraMetadataLabels`                  | An extra set of labels which are applied to chao and the daemonset | `latest`                                                                |
 | `nodeSelector`                         | Map of node labels for pod assignment                          | `{}`                                                                        |
 | `tolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
-| `affinity`                             | Map of node/pod affinities                                     | `{}`                                                                        |                                                                    |
+| `affinity`                             | Map of node/pod affinities                                     | `{}`                                                                        |
 | `gremlin.apparmor`                     | Apparmor profile to set for the Gremlin Daemon                 | `""` (When empty, no profile is set)                                        |
 | `gremlin.container.driver`             | Specifies which container driver with which to run Gremlin. [See example][driverexample] | `docker` | 
 | `gremlin.cgroup.root`                  | Specifies the absolute path for the cgroup controller root on target host systems | `/sys/fs/cgroup` |

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -20,7 +20,7 @@ their default values. See values.yaml for all available options.
 | `chaoimage.pullPolicy`                 | Container pull policy for the `chao` container                 | `Always`                                                                    |
 | `chaoimage.repository`                 | Container image to use for the `chao` container                | `gremlin/chao`                                                              |
 | `chaoimage.tag`                        | Container image tag to deploy for the `chao` container         | `latest`                                                                    |
-| `extraMetadataLabels`                  | An extra set of labels which are applied to chao, the daemonset, and their service accounts | `{}`                                                                    |
+| `extraCommonLabels`                    | An extra set of labels which are applied to chao, the daemonset, and their service accounts | `{}`                                           |
 | `nodeSelector`                         | Map of node labels for pod assignment                          | `{}`                                                                        |
 | `tolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
 | `affinity`                             | Map of node/pod affinities                                     | `{}`                                                                        |

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -20,7 +20,7 @@ their default values. See values.yaml for all available options.
 | `chaoimage.pullPolicy`                 | Container pull policy for the `chao` container                 | `Always`                                                                    |
 | `chaoimage.repository`                 | Container image to use for the `chao` container                | `gremlin/chao`                                                              |
 | `chaoimage.tag`                        | Container image tag to deploy for the `chao` container         | `latest`                                                                    |
-| `extraMetadataLabels`                  | An extra set of labels which are applied to chao and the daemonset | `latest`                                                                |
+| `extraMetadataLabels`                  | An extra set of labels which are applied to chao and the daemonset | `{}`                                                                    |
 | `nodeSelector`                         | Map of node labels for pod assignment                          | `{}`                                                                        |
 | `tolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
 | `affinity`                             | Map of node/pod affinities                                     | `{}`                                                                        |

--- a/gremlin/templates/_helpers.tpl
+++ b/gremlin/templates/_helpers.tpl
@@ -32,6 +32,15 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Common labels
+*/}}
+{{- define "gremlin.commonLabels" -}}
+{{- if .Values.extraCommonLabels }}
+{{ toYaml .Values.extraCommonLabels }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Because we've evolved the recommended way to pass the secret name over time, we hide the following order of operations behind this computed value:
 In later versions of this chart, we will remove the use of `.Values.gremlin.client.secretName` and the fallback value of `gremlin-team-cert`
 */}}

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/instance: chao
     app.kubernetes.io/name: chao
     app.kubernetes.io/version: "1"
+    {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 4 }}
   name: chao
   namespace: {{ .Release.Namespace }}
 spec:
@@ -21,6 +22,7 @@ spec:
         app.kubernetes.io/instance: chao
         app.kubernetes.io/name: chao
         app.kubernetes.io/version: "1"
+        {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 8 }}
     spec:
       serviceAccountName: chao
       containers:

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: chao
     app.kubernetes.io/name: chao
     app.kubernetes.io/version: "1"
-    {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 4 }}
+    {{- include "gremlin.commonLabels" . | indent 4 }}
   name: chao
   namespace: {{ .Release.Namespace }}
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/instance: chao
         app.kubernetes.io/name: chao
         app.kubernetes.io/version: "1"
-        {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 8 }}
+        {{- include "gremlin.commonLabels" . | indent 8 }}
     spec:
       serviceAccountName: chao
       containers:

--- a/gremlin/templates/chao-service-account.yaml
+++ b/gremlin/templates/chao-service-account.yaml
@@ -4,11 +4,15 @@ kind: ServiceAccount
 metadata:
   name: chao
   namespace: {{ .Release.Namespace }}
+  labels: 
+    {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: gremlin-watcher
+  labels:
+    {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 4 }}
 rules:
   - apiGroups: ["apps"]
     resources: ["replicasets", "deployments", "statefulsets", "daemonsets"]
@@ -21,6 +25,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: chao
+  labels:
+    {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: chao

--- a/gremlin/templates/chao-service-account.yaml
+++ b/gremlin/templates/chao-service-account.yaml
@@ -5,14 +5,14 @@ metadata:
   name: chao
   namespace: {{ .Release.Namespace }}
   labels: 
-    {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 4 }}
+    {{- include "gremlin.commonLabels" . | indent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: gremlin-watcher
   labels:
-    {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 4 }}
+    {{- include "gremlin.commonLabels" . | indent 4 }}
 rules:
   - apiGroups: ["apps"]
     resources: ["replicasets", "deployments", "statefulsets", "daemonsets"]
@@ -26,7 +26,7 @@ kind: ClusterRoleBinding
 metadata:
   name: chao
   labels:
-    {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 4 }}
+    {{- include "gremlin.commonLabels" . | indent 4 }}
 subjects:
   - kind: ServiceAccount
     name: chao

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     version: v1
-    {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 4 }}
+    {{- include "gremlin.commonLabels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         version: v1
-        {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 8 }}
+        {{- include "gremlin.commonLabels" . | indent 8 }}
       {{- if or .Values.gremlin.apparmor .Values.gremlin.podSecurity.seccomp.enabled }}
       annotations:
         {{- if .Values.gremlin.apparmor }}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     version: v1
+    {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -21,6 +22,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         version: v1
+        {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 8 }}
       {{- if or .Values.gremlin.apparmor .Values.gremlin.podSecurity.seccomp.enabled }}
       annotations:
         {{- if .Values.gremlin.apparmor }}

--- a/gremlin/templates/gremlin-service-account.yaml
+++ b/gremlin/templates/gremlin-service-account.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   name: gremlin
   namespace: {{ .Release.Namespace }}
+  labels: 
+    {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 4 }}
 {{ if .Values.gremlin.podSecurity.podSecurityPolicy.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/gremlin/templates/gremlin-service-account.yaml
+++ b/gremlin/templates/gremlin-service-account.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gremlin
   namespace: {{ .Release.Namespace }}
   labels: 
-    {{- toYaml .Values.extraMetadataLabels | trimSuffix "\n" | nindent 4 }}
+    {{- include "gremlin.commonLabels" . | indent 4 }}
 {{ if .Values.gremlin.podSecurity.podSecurityPolicy.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -21,9 +21,10 @@ tolerations: []
 
 affinity: {}
 
-extraMetadataLabels: {}
+extraCommonLabels: {}
 
 gremlin:
+
   # gremlin.apparmor -
   # Gremlin assumes apparmor is not enabled by default and so it will not specify any apparmor profile to use
   # You may need to provide a specific profile if your environment requires it.
@@ -94,6 +95,7 @@ gremlin:
     create: true
 
   podSecurity:
+
     # gremlin.podSecurity.allowPrivilegeEscalation -
     # Allows Gremlin containers privilege escalation powers
     allowPrivilegeEscalation: false
@@ -103,32 +105,32 @@ gremlin:
     #   Daemonset as well as any pod security resource that governs it. Capabilities that are required for specific
     #   attacks can be removed from this list if running such attacks are not desired.
     capabilities:
-      - KILL # Required to run Process Killer attacks
-      - NET_ADMIN # Required to run network attacks
-      - SYS_BOOT # Required to run Shutdown attacks
-      - SYS_TIME # Required to run Time Travel attacks
+      - KILL        # Required to run Process Killer attacks
+      - NET_ADMIN   # Required to run network attacks
+      - SYS_BOOT    # Required to run Shutdown attacks
+      - SYS_TIME    # Required to run Time Travel attacks
 
-      - SYS_ADMIN # Required by container drivers: docker-runc, crio-runc, containerd-runc
+      - SYS_ADMIN   # Required by container drivers: docker-runc, crio-runc, containerd-runc
+                    #   to run attacks against running containers
 
-        #   to run attacks against running containers
-      - SYS_PTRACE # Required by container drivers: docker-runc, crio-runc, containerd-runc
+      - SYS_PTRACE  # Required by container drivers: docker-runc, crio-runc, containerd-runc
+                    #   to determine if Gremlin is in the host's pid namespace
 
-        #   to determine if Gremlin is in the host's pid namespace
-      - SETFCAP # Required by container drivers: docker-runc, crio-runc, containerd-runc
+      - SETFCAP     # Required by container drivers: docker-runc, crio-runc, containerd-runc
+                    #   to set capabilities on Gremlin attack sidecars
 
-        #   to set capabilities on Gremlin attack sidecars
       - AUDIT_WRITE # Required by container drivers: docker-runc, crio-runc, containerd-runc
+                    #   to write to the Kernel's audit log
 
-        #   to write to the Kernel's audit log
-      - MKNOD # Required by container drivers: docker-runc, crio-runc, containerd-runc
+      - MKNOD       # Required by container drivers: docker-runc, crio-runc, containerd-runc
+                    #   to create new devices for Gremlin attack sidecars
 
-        #   to create new devices for Gremlin attack sidecars
-      - SYS_CHROOT # Required by container drivers: docker-runc, crio-runc, containerd-runc
+      - SYS_CHROOT  # Required by container drivers: docker-runc, crio-runc, containerd-runc
+                    #   to create and enter new namespaces for Gremlin attack sidecars
 
-        #   to create and enter new namespaces for Gremlin attack sidecars
-      - NET_RAW # Required by container drivers: docker-runc, crio-runc, containerd-runc
-        #   Not actively used by Gremlin but requested by sidecars
-        #   This capability will be removed in a later release
+      - NET_RAW     # Required by container drivers: docker-runc, crio-runc, containerd-runc
+                    #   Not actively used by Gremlin but requested by sidecars
+                    #   This capability will be removed in a later release
 
     # gremlin.podSecurity.readOnlyRootFilesystem -
     # Forces the Gremlin Daemonset containers to run with a read-only root filesystem
@@ -147,9 +149,9 @@ gremlin:
     # gremlin.podSecurity.volumes -
     # Specifies the volume types the Gremlin Daemonset is allowed to use
     volumes:
-      - configMap # Required when the Gremlin Daemonset installs a seccomp profile (see gremlin.podSecurity.seccomp)
-      - secret # Required to store and load secret information like certificates that authenticate Gremlin
-      - hostPath # Required by Gremlin to store attack logs (/var/log/gremlin) and attack state (/var/lib/gremlin)
+      - configMap   # Required when the Gremlin Daemonset installs a seccomp profile (see gremlin.podSecurity.seccomp)
+      - secret      # Required to store and load secret information like certificates that authenticate Gremlin
+      - hostPath    # Required by Gremlin to store attack logs (/var/log/gremlin) and attack state (/var/lib/gremlin)
 
     podSecurityPolicy:
       # gremlin.podSecurity.podSecurityPolicy.create -

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -21,8 +21,9 @@ tolerations: []
 
 affinity: {}
 
-gremlin:
+extraMetadataLabels: {}
 
+gremlin:
   # gremlin.apparmor -
   # Gremlin assumes apparmor is not enabled by default and so it will not specify any apparmor profile to use
   # You may need to provide a specific profile if your environment requires it.
@@ -93,7 +94,6 @@ gremlin:
     create: true
 
   podSecurity:
-
     # gremlin.podSecurity.allowPrivilegeEscalation -
     # Allows Gremlin containers privilege escalation powers
     allowPrivilegeEscalation: false
@@ -103,32 +103,32 @@ gremlin:
     #   Daemonset as well as any pod security resource that governs it. Capabilities that are required for specific
     #   attacks can be removed from this list if running such attacks are not desired.
     capabilities:
-      - KILL        # Required to run Process Killer attacks
-      - NET_ADMIN   # Required to run network attacks
-      - SYS_BOOT    # Required to run Shutdown attacks
-      - SYS_TIME    # Required to run Time Travel attacks
+      - KILL # Required to run Process Killer attacks
+      - NET_ADMIN # Required to run network attacks
+      - SYS_BOOT # Required to run Shutdown attacks
+      - SYS_TIME # Required to run Time Travel attacks
 
-      - SYS_ADMIN   # Required by container drivers: docker-runc, crio-runc, containerd-runc
-                    #   to run attacks against running containers
+      - SYS_ADMIN # Required by container drivers: docker-runc, crio-runc, containerd-runc
 
-      - SYS_PTRACE  # Required by container drivers: docker-runc, crio-runc, containerd-runc
-                    #   to determine if Gremlin is in the host's pid namespace
+        #   to run attacks against running containers
+      - SYS_PTRACE # Required by container drivers: docker-runc, crio-runc, containerd-runc
 
-      - SETFCAP     # Required by container drivers: docker-runc, crio-runc, containerd-runc
-                    #   to set capabilities on Gremlin attack sidecars
+        #   to determine if Gremlin is in the host's pid namespace
+      - SETFCAP # Required by container drivers: docker-runc, crio-runc, containerd-runc
 
+        #   to set capabilities on Gremlin attack sidecars
       - AUDIT_WRITE # Required by container drivers: docker-runc, crio-runc, containerd-runc
-                    #   to write to the Kernel's audit log
 
-      - MKNOD       # Required by container drivers: docker-runc, crio-runc, containerd-runc
-                    #   to create new devices for Gremlin attack sidecars
+        #   to write to the Kernel's audit log
+      - MKNOD # Required by container drivers: docker-runc, crio-runc, containerd-runc
 
-      - SYS_CHROOT  # Required by container drivers: docker-runc, crio-runc, containerd-runc
-                    #   to create and enter new namespaces for Gremlin attack sidecars
+        #   to create new devices for Gremlin attack sidecars
+      - SYS_CHROOT # Required by container drivers: docker-runc, crio-runc, containerd-runc
 
-      - NET_RAW     # Required by container drivers: docker-runc, crio-runc, containerd-runc
-                    #   Not actively used by Gremlin but requested by sidecars
-                    #   This capability will be removed in a later release
+        #   to create and enter new namespaces for Gremlin attack sidecars
+      - NET_RAW # Required by container drivers: docker-runc, crio-runc, containerd-runc
+        #   Not actively used by Gremlin but requested by sidecars
+        #   This capability will be removed in a later release
 
     # gremlin.podSecurity.readOnlyRootFilesystem -
     # Forces the Gremlin Daemonset containers to run with a read-only root filesystem
@@ -147,9 +147,9 @@ gremlin:
     # gremlin.podSecurity.volumes -
     # Specifies the volume types the Gremlin Daemonset is allowed to use
     volumes:
-      - configMap   # Required when the Gremlin Daemonset installs a seccomp profile (see gremlin.podSecurity.seccomp)
-      - secret      # Required to store and load secret information like certificates that authenticate Gremlin
-      - hostPath    # Required by Gremlin to store attack logs (/var/log/gremlin) and attack state (/var/lib/gremlin)
+      - configMap # Required when the Gremlin Daemonset installs a seccomp profile (see gremlin.podSecurity.seccomp)
+      - secret # Required to store and load secret information like certificates that authenticate Gremlin
+      - hostPath # Required by Gremlin to store attack logs (/var/log/gremlin) and attack state (/var/lib/gremlin)
 
     podSecurityPolicy:
       # gremlin.podSecurity.podSecurityPolicy.create -


### PR DESCRIPTION
These labels can be used for standards which apply to all resources in a cluster (e.g. accounting tags.)

I only added them to resources which will be created using our expected configuration. If this fork is merged back in, I will add it to the other resources at that point.