### PR TITLE
Split Scheduling Constraints

### DIFF
--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -20,8 +20,10 @@ their default values. See values.yaml for all available options.
 | `chaoimage.pullPolicy`                 | Container pull policy for the `chao` container                 | `Always`                                                                    |
 | `chaoimage.repository`                 | Container image to use for the `chao` container                | `gremlin/chao`                                                              |
 | `chaoimage.tag`                        | Container image tag to deploy for the `chao` container         | `latest`                                                                    |
-| `nodeSelector`                         | Map of node labels for pod assignment                          | `{}`                                                                        |
-| `tolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
+| `daemonSetNodeSelector`                         | Map of node labels for pod assignment                 | `{}`|
+| `chaoNodeSelector`                         | Map of node labels for chao deployment                 | `{}`|
+| `daemonSetTolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
+| `chaoTolerations`                          | List of node taints to tolerate for chao deployment                             | `[]
 | `affinity`                             | Map of node/pod affinities                                     | `{}`                                                                        |                                                                    |
 | `gremlin.apparmor`                     | Apparmor profile to set for the Gremlin Daemon                 | `""` (When empty, no profile is set)                                        |
 | `gremlin.container.driver`             | Specifies which container driver with which to run Gremlin. [See example][driverexample] | `docker` | 
@@ -71,11 +73,11 @@ $ helm install gremlin gremlin/gremlin \
   --set       gremlin.secret.teamID="$GREMLIN_TEAM_ID" \
   --set-file  gremlin.secret.certificate=/path/to/gremlin.cert \
   --set-file  gremlin.secret.key=/path/to/gremlin.key \
-  --set       'tolerations[0].effect=NoSchedule' \
-  --set       'tolerations[0].key=node-role.kubernetes.io/master' \
-  --set       'tolerations[0].operator=Exists'
+  --set       'daemonSetTolerations[0].effect=NoSchedule' \
+  --set       'daemonSetTolerations[0].key=node-role.kubernetes.io/master' \
+  --set       'daemonSetTolerations[0].operator=Exists'
 ```
-_note_: Depending on your shell you may need different quoting around `tolerations[0]`
+_note_: Depending on your shell you may need different quoting around `daemonSetTolerations[0]`
 
 ## Installation
 

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -20,10 +20,10 @@ their default values. See values.yaml for all available options.
 | `chaoimage.pullPolicy`                 | Container pull policy for the `chao` container                 | `Always`                                                                    |
 | `chaoimage.repository`                 | Container image to use for the `chao` container                | `gremlin/chao`                                                              |
 | `chaoimage.tag`                        | Container image tag to deploy for the `chao` container         | `latest`                                                                    |
-| `daemonSetNodeSelector`                         | Map of node labels for pod assignment                 | `{}`|
-| `chaoNodeSelector`                         | Map of node labels for chao deployment                 | `{}`|
-| `daemonSetTolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
-| `chaoTolerations`                          | List of node taints to tolerate for chao deployment                             | `[]
+| `daemonset.nodeSelector`                         | Map of node labels for pod assignment                 | `{}`|
+| `chao.nodeSelector`                         | Map of node labels for chao deployment                 | `{}`|
+| `daemonset.tolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
+| `chao.tolerations`                          | List of node taints to tolerate for chao deployment                             | `[]`
 | `affinity`                             | Map of node/pod affinities                                     | `{}`                                                                        |                                                                    |
 | `gremlin.apparmor`                     | Apparmor profile to set for the Gremlin Daemon                 | `""` (When empty, no profile is set)                                        |
 | `gremlin.container.driver`             | Specifies which container driver with which to run Gremlin. [See example][driverexample] | `docker` | 
@@ -73,11 +73,11 @@ $ helm install gremlin gremlin/gremlin \
   --set       gremlin.secret.teamID="$GREMLIN_TEAM_ID" \
   --set-file  gremlin.secret.certificate=/path/to/gremlin.cert \
   --set-file  gremlin.secret.key=/path/to/gremlin.key \
-  --set       'daemonSetTolerations[0].effect=NoSchedule' \
-  --set       'daemonSetTolerations[0].key=node-role.kubernetes.io/master' \
-  --set       'daemonSetTolerations[0].operator=Exists'
+  --set       'daemonset.tolerations[0].effect=NoSchedule' \
+  --set       'daemonset.tolerations[0].key=node-role.kubernetes.io/master' \
+  --set       'daemonset.tolerations[0].operator=Exists'
 ```
-_note_: Depending on your shell you may need different quoting around `daemonSetTolerations[0]`
+_note_: Depending on your shell you may need different quoting around `daemonset.tolerations[0]`
 
 ## Installation
 

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -20,9 +20,9 @@ their default values. See values.yaml for all available options.
 | `chaoimage.pullPolicy`                 | Container pull policy for the `chao` container                 | `Always`                                                                    |
 | `chaoimage.repository`                 | Container image to use for the `chao` container                | `gremlin/chao`                                                              |
 | `chaoimage.tag`                        | Container image tag to deploy for the `chao` container         | `latest`                                                                    |
-| `daemonSetNodeSelector`                         | Map of node labels for pod assignment                 | `{}`|
+| `daemonSetNodeSelector`                         | Map of node labels for Gremlin pod assignment                 | `{}`|
 | `chaoNodeSelector`                         | Map of node labels for chao deployment                 | `{}`|
-| `daemonSetTolerations`                          | List of node taints to tolerate                                | `[]`                                                                        |
+| `daemonSetTolerations`                          | List of node taints to tolerate for Gremlin pod assignment                                | `[]`                                                                        |
 | `chaoTolerations`                          | List of node taints to tolerate for chao deployment                             | `[]
 | `affinity`                             | Map of node/pod affinities                                     | `{}`                                                                        |                                                                    |
 | `gremlin.apparmor`                     | Apparmor profile to set for the Gremlin Daemon                 | `""` (When empty, no profile is set)                                        |

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -23,11 +23,13 @@ spec:
         app.kubernetes.io/version: "1"
     spec:
       serviceAccountName: chao
-      {{- if .Values.chaoNodeSelector }}
-      nodeSelector: {{ toYaml .Values.chaoNodeSelector | trimSuffix "\n" | nindent 8 }}
+      {{- if .Values.chao.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.chao.nodeSelector | nindent 8}}
       {{- end }}
-      {{- if .Values.chaoTolerations }}
-      tolerations: {{ toYaml .Values.chaoTolerations | trimSuffix "\n" | nindent 8 }}
+      {{- if .Values.chao.tolerations }}
+      tolerations: 
+        {{- toYaml .Values.chao.tolerations | nindent 8}}
       {{- end }}
       containers:
         - image: {{ .Values.chaoimage.repository }}:{{ .Values.chaoimage.tag }}

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -23,6 +23,12 @@ spec:
         app.kubernetes.io/version: "1"
     spec:
       serviceAccountName: chao
+      {{- if .Values.chaoNodeSelector }}
+      selector: {{ toYaml .Values.chaoNodeSelector | trimSuffix "\n" | nindent 8 }}
+      {{- end }}
+      {{- if .Values.chaoTolerations }}
+      tolerations: {{ toYaml .Values.chaoTolerations | trimSuffix "\n" | nindent 8 }}
+      {{- end }}
       containers:
         - image: {{ .Values.chaoimage.repository }}:{{ .Values.chaoimage.tag }}
         {{- if .Values.resources }}

--- a/gremlin/templates/chao-deployment.yaml
+++ b/gremlin/templates/chao-deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       serviceAccountName: chao
       {{- if .Values.chaoNodeSelector }}
-      selector: {{ toYaml .Values.chaoNodeSelector | trimSuffix "\n" | nindent 8 }}
+      nodeSelector: {{ toYaml .Values.chaoNodeSelector | trimSuffix "\n" | nindent 8 }}
       {{- end }}
       {{- if .Values.chaoTolerations }}
       tolerations: {{ toYaml .Values.chaoTolerations | trimSuffix "\n" | nindent 8 }}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -35,11 +35,13 @@ spec:
       {{- if .Values.affinity }}
       affinity: {{ toYaml .Values.affinity | trimSuffix "\n" | indent 8 }}
       {{- end }}
-      {{- if .Values.daemonSetNodeSelector }}
-      nodeSelector: {{ toYaml .Values.daemonSetNodeSelector | trimSuffix "\n" | nindent 8 }}
+      {{- if .Values.daemonset.nodeSelector }}
+      nodeSelector: 
+        {{- toYaml .Values.daemonset.nodeSelector | nindent 8}}
       {{- end }}
-      {{- if .Values.daemonSetTolerations }}
-      tolerations: {{ toYaml .Values.daemonSetTolerations | trimSuffix "\n" | nindent 8 }}
+      {{- if .Values.daemonset.tolerations }}
+      tolerations: 
+        {{- toYaml .Values.daemonset.tolerations | nindent 8}}
       {{- end }}
       hostPID: {{ .Values.gremlin.hostPID }}
       hostNetwork: {{ .Values.gremlin.hostNetwork }}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
       affinity: {{ toYaml .Values.affinity | trimSuffix "\n" | indent 8 }}
       {{- end }}
       {{- if .Values.daemonSetNodeSelector }}
-      selector: {{ toYaml .Values.daemonSetNodeSelector | trimSuffix "\n" | nindent 8 }}
+      nodeSelector: {{ toYaml .Values.daemonSetNodeSelector | trimSuffix "\n" | nindent 8 }}
       {{- end }}
       {{- if .Values.daemonSetTolerations }}
       tolerations: {{ toYaml .Values.daemonSetTolerations | trimSuffix "\n" | nindent 8 }}

--- a/gremlin/templates/daemonset.yaml
+++ b/gremlin/templates/daemonset.yaml
@@ -35,11 +35,11 @@ spec:
       {{- if .Values.affinity }}
       affinity: {{ toYaml .Values.affinity | trimSuffix "\n" | indent 8 }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{ toYaml .Values.nodeSelector | trimSuffix "\n" | nindent 8 }}
+      {{- if .Values.daemonSetNodeSelector }}
+      selector: {{ toYaml .Values.daemonSetNodeSelector | trimSuffix "\n" | nindent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
-      tolerations: {{ toYaml .Values.tolerations | trimSuffix "\n" | nindent 8 }}
+      {{- if .Values.daemonSetTolerations }}
+      tolerations: {{ toYaml .Values.daemonSetTolerations | trimSuffix "\n" | nindent 8 }}
       {{- end }}
       hostPID: {{ .Values.gremlin.hostPID }}
       hostNetwork: {{ .Values.gremlin.hostNetwork }}

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -15,11 +15,13 @@ chaoimage:
 nameOverride: ""
 fullnameOverride: ""
 
-daemonSetNodeSelector: {}
-chaoNodeSelector: {}
+daemonset:
+  tolerations: []
+  nodeSelector: {}
 
-daemonSetTolerations: []
-chaoTolerations: []
+chao: 
+  tolerations: []
+  nodeSelector: {}
 
 affinity: {}
 

--- a/gremlin/values.yaml
+++ b/gremlin/values.yaml
@@ -15,9 +15,11 @@ chaoimage:
 nameOverride: ""
 fullnameOverride: ""
 
-nodeSelector: {}
+daemonSetNodeSelector: {}
+chaoNodeSelector: {}
 
-tolerations: []
+daemonSetTolerations: []
+chaoTolerations: []
 
 affinity: {}
 


### PR DESCRIPTION
Context: 

Chao: Is the [Gremlin](https://www.gremlin.com/) Kubernetes Client. It communicates with Kubernetes to perform service discovery.
DaemonSet: Deploys the Gremlin container to pods. Those Gremlin containers execute attacks.

This change allows a Gremlin deployment to have separate scheduling rules for the Chao deployment versus the Daemonset. That is important since some services have isolated node pools, which we don't want to deploy Chao to.

I did not separate affinity, since the node selector / tolerations should be sufficient to make sure Chao lands in the right node pool.